### PR TITLE
Adding of the Dependency dataclass, and the tool now take into accoun…

### DIFF
--- a/dep_check/checker.py
+++ b/dep_check/checker.py
@@ -40,7 +40,7 @@ def check_dependency(dependency: Dependency, rules: Rules) -> Rules:
         if re.match("{}$".format(wildcard_to_regex(rule)), dependency.main_import):
             used_rule = (module, rule)
             return set((used_rule,))
-    if not dependency.other_imports:
+    if not dependency.sub_imports:
         raise NotAllowedDependencyException(
             dependency.main_import, [r for _, r in rules]
         )
@@ -50,7 +50,7 @@ def check_dependency(dependency: Dependency, rules: Rules) -> Rules:
 
 def check_import_from_dependency(dependency: Dependency, rules: Rules) -> Rules:
     used_rules: Rules = set()
-    for import_module in dependency.other_imports:
+    for import_module in dependency.sub_imports:
         used_rule = None
         for module, rule in rules:
             if re.match(
@@ -60,7 +60,6 @@ def check_import_from_dependency(dependency: Dependency, rules: Rules) -> Rules:
                 used_rule = (module, rule)
                 used_rules.add(used_rule)
         if not used_rule:
-            print("yessay")
             raise NotAllowedDependencyException(
                 Module(f"{dependency.main_import}.{import_module}"),
                 [r for _, r in rules],

--- a/dep_check/checker.py
+++ b/dep_check/checker.py
@@ -4,7 +4,14 @@ Check that dependencies follow a set of rules.
 import re
 from typing import List, Optional
 
-from dep_check.models import Module, ModuleWildcard, Rule, Rules, wildcard_to_regex
+from dep_check.models import (
+    Dependency,
+    Module,
+    ModuleWildcard,
+    Rule,
+    Rules,
+    wildcard_to_regex,
+)
 
 
 class NotAllowedDependencyException(Exception):
@@ -24,15 +31,38 @@ class NotAllowedDependencyException(Exception):
         self.authorized_modules = authorized_modules
 
 
-def check_dependency(dependency: Module, rules: Rules) -> Rule:
+def check_dependency(dependency: Dependency, rules: Rules) -> Rules:
     """
     Check that dependencies match a given set of rules.
     """
     used_rule: Optional[Rule] = None
     for module, rule in rules:
-        if re.match("{}$".format(wildcard_to_regex(rule)), dependency):
+        if re.match("{}$".format(wildcard_to_regex(rule)), dependency.main_import):
             used_rule = (module, rule)
-            break
-    if not used_rule:
-        raise NotAllowedDependencyException(dependency, [r for _, r in rules])
-    return used_rule
+            return set((used_rule,))
+    if not dependency.other_imports:
+        raise NotAllowedDependencyException(
+            dependency.main_import, [r for _, r in rules]
+        )
+
+    return check_import_from_dependency(dependency, rules)
+
+
+def check_import_from_dependency(dependency: Dependency, rules: Rules) -> Rules:
+    used_rules: Rules = set()
+    for import_module in dependency.other_imports:
+        used_rule = None
+        for module, rule in rules:
+            if re.match(
+                "{}$".format(wildcard_to_regex(rule)),
+                f"{dependency.main_import}.{import_module}",
+            ):
+                used_rule = (module, rule)
+                used_rules.add(used_rule)
+        if not used_rule:
+            print("yessay")
+            raise NotAllowedDependencyException(
+                Module(f"{dependency.main_import}.{import_module}"),
+                [r for _, r in rules],
+            )
+    return used_rules

--- a/dep_check/dependency_finder.py
+++ b/dep_check/dependency_finder.py
@@ -1,7 +1,7 @@
 import ast
 from typing import Any, FrozenSet, List
 
-from dep_check.models import Dependencies, Module, SourceFile
+from dep_check.models import Dependencies, Dependency, Module, SourceFile
 
 
 class _ImportVisitor(ast.NodeVisitor):
@@ -21,9 +21,9 @@ class _ImportVisitor(ast.NodeVisitor):
         return self._dependencies
 
     def visit(self, node: Any) -> None:
-        modules: FrozenSet[Module] = frozenset()
+        modules: FrozenSet[Dependency] = frozenset()
         if isinstance(node, ast.Import):
-            modules = frozenset(Module(alias.name) for alias in node.names)
+            modules = frozenset(Dependency(Module(alias.name)) for alias in node.names)
 
         elif isinstance(node, ast.ImportFrom):
             module = Module(node.module or "")
@@ -33,7 +33,38 @@ class _ImportVisitor(ast.NodeVisitor):
                     module = Module("{}.{}".format(parent_module, node.module))
                 else:
                     module = Module(parent_module)
-            modules = frozenset((module,))
+            modules = frozenset((Dependency(module),))
+        self._dependencies |= modules
+
+        super().visit(node)
+
+
+class _ImportFromVisitor(ast.NodeVisitor):
+    def __init__(self, current_module: str) -> None:
+        self._dependencies: Dependencies = set()
+        self.current_module_parts: List[str] = current_module.split(".")
+
+    @property
+    def dependencies(self) -> Dependencies:
+        """
+        Dependencies found during the scan.
+        """
+        return self._dependencies
+
+    def visit(self, node: Any) -> None:
+        modules: FrozenSet[Dependency] = frozenset()
+        if isinstance(node, ast.Import):
+            modules = frozenset(Dependency(Module(alias.name)) for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            module = Module(node.module or "")
+            if node.level:
+                parent_module = ".".join(self.current_module_parts[: -node.level])
+                if node.module:
+                    module = Module("{}.{}".format(parent_module, node.module))
+                else:
+                    module = Module(parent_module)
+            other_imports = frozenset(Module(alias.name) for alias in node.names)
+            modules = frozenset((Dependency(module, other_imports),))
 
         self._dependencies |= modules
 
@@ -45,6 +76,16 @@ def find_dependencies(source_file: SourceFile) -> Dependencies:
     Scan a python source file and return its dependencies.
     """
     visitor = _ImportVisitor(source_file.module)
+    node = ast.parse(source_file.code)
+    visitor.visit(node)
+    return visitor.dependencies
+
+
+def find_import_from_dependencies(source_file: SourceFile) -> Dependencies:
+    """
+    Scan a python source file and return its dependencies.
+    """
+    visitor = _ImportFromVisitor(source_file.module)
     node = ast.parse(source_file.code)
     visitor.visit(node)
     return visitor.dependencies

--- a/dep_check/dependency_finder.py
+++ b/dep_check/dependency_finder.py
@@ -63,8 +63,8 @@ class _ImportFromVisitor(ast.NodeVisitor):
                     module = Module("{}.{}".format(parent_module, node.module))
                 else:
                     module = Module(parent_module)
-            other_imports = frozenset(Module(alias.name) for alias in node.names)
-            modules = frozenset((Dependency(module, other_imports),))
+            sub_imports = frozenset(Module(alias.name) for alias in node.names)
+            modules = frozenset((Dependency(module, sub_imports),))
 
         self._dependencies |= modules
 

--- a/dep_check/infra/io.py
+++ b/dep_check/infra/io.py
@@ -77,7 +77,7 @@ def read_graph_config(conf_path: str) -> Dict:
 @dataclass(init=False)
 class Graph:
     """
-    Dataclass representing the informations to draw a graph
+    Dataclass representing the information to draw a graph
     """
 
     def __init__(self, svg_file_name: str, graph_config: Optional[Dict] = None):

--- a/dep_check/infra/io.py
+++ b/dep_check/infra/io.py
@@ -138,9 +138,9 @@ class GraphDrawer(IGraphDrawer):
                 list_modules=str(modules)[1:-1].replace("'", '"'),
             )
 
-        for module, rules in global_dep.items():
-            for rule in rules:
-                self.body += '"{}" -> "{}"\n'.format(module, rule)
+        for module, deps in global_dep.items():
+            for dep in deps:
+                self.body += '"{}" -> "{}"\n'.format(module, dep.main_import)
 
         with open(self.graph.dot_file_name, "w") as out:
             out.write(self.header)

--- a/dep_check/infra/std_lib_filter.py
+++ b/dep_check/infra/std_lib_filter.py
@@ -332,4 +332,8 @@ class StdLibSimpleFilter(IStdLibFilter):
     """
 
     def filter(self, dependencies: Dependencies) -> Dependencies:
-        return dependencies - _KNOWN_STANDARD_LIBRARIES
+        return dependencies - {
+            dep
+            for dep in dependencies
+            if dep.main_import.startswith(tuple(_KNOWN_STANDARD_LIBRARIES))
+        }

--- a/dep_check/models.py
+++ b/dep_check/models.py
@@ -12,10 +12,13 @@ Module = NewType("Module", str)
 class Dependency:
     """
     A complete information about a dependency
+
+    With 'from a import b, c', main_import = 'a' and sub_imports = {b, c}
+    With 'import e', main_import = 'e' and sub_imports = {}
     """
 
     main_import: Module = Module("")
-    other_imports: FrozenSet[Module] = field(default_factory=frozenset)
+    sub_imports: FrozenSet[Module] = field(default_factory=frozenset)
 
 
 Dependencies = Set[Dependency]
@@ -55,8 +58,7 @@ def iter_all_modules(global_dep: GlobalDependencies) -> Iterator[Module]:
     def iter_(global_dep: GlobalDependencies) -> Iterator[Module]:
         for module, dependencies in global_dep.items():
             yield module
-            for dep in dependencies:
-                yield dep.main_import
+            yield from (d.main_import for d in dependencies)
 
     return iter(set(iter_(global_dep)))
 

--- a/dep_check/models.py
+++ b/dep_check/models.py
@@ -2,11 +2,24 @@
 Define all the business models of the application.
 """
 
-from dataclasses import dataclass
-from typing import Dict, Iterator, List, NewType, Set, Tuple
+from dataclasses import dataclass, field
+from typing import Dict, FrozenSet, Iterator, List, NewType, Set, Tuple
 
 Module = NewType("Module", str)
-Dependencies = Set[Module]
+
+
+@dataclass(frozen=True)
+class Dependency:
+    """
+    A complete information about a dependency
+    """
+
+    main_import: Module = Module("")
+    other_imports: FrozenSet[Module] = field(default_factory=frozenset)
+
+
+Dependencies = Set[Dependency]
+
 SourceCode = NewType("SourceCode", str)
 
 ModuleWildcard = NewType("ModuleWildcard", str)
@@ -42,7 +55,8 @@ def iter_all_modules(global_dep: GlobalDependencies) -> Iterator[Module]:
     def iter_(global_dep: GlobalDependencies) -> Iterator[Module]:
         for module, dependencies in global_dep.items():
             yield module
-            yield from dependencies
+            for dep in dependencies:
+                yield dep.main_import
 
     return iter(set(iter_(global_dep)))
 

--- a/dep_check/models.py
+++ b/dep_check/models.py
@@ -46,7 +46,7 @@ def wildcard_to_regex(module: ModuleWildcard) -> str:
     module_regex = module.replace(".", "\\.").replace("*", ".*")
     module_regex = module_regex.replace("[!", "[^").replace("?", ".?")
 
-    # Special char including a module along with all its submodules:
+    # Special char including a module along with all its sub-modules:
     module_regex = module_regex.replace("%", r"(\..*)?$")
     return module_regex
 

--- a/dep_check/use_cases/build.py
+++ b/dep_check/use_cases/build.py
@@ -50,7 +50,7 @@ class BuildConfigurationUC:
         dependency_rules = {}
         for module, dependencies in global_dependencies.items():
             dependency_rules[str(module)] = [
-                ModuleWildcard(dependency) for dependency in dependencies
+                ModuleWildcard(dependency.main_import) for dependency in dependencies
             ]
 
         self.printer.write(Configuration(dependency_rules))

--- a/tests/fakefile.py
+++ b/tests/fakefile.py
@@ -1,4 +1,4 @@
-from dep_check.models import Module, SourceCode, SourceFile
+from dep_check.models import Dependency, Module, SourceCode, SourceFile
 
 SIMPLE_FILE = SourceFile(
     module=Module("simple_module"),
@@ -35,15 +35,21 @@ from abc import ABC
 
 GLOBAL_DEPENDENCIES = {
     "simple_module": set(
-        (Module("module"), Module("module.inside.module"), Module("amodule"))
+        (
+            Dependency(Module("module")),
+            Dependency(Module("module.inside.module")),
+            Dependency(Module("amodule")),
+        )
     ),
     "amodule.local_module": set(
         (
-            Module("module"),
-            Module("module.inside.module"),
-            Module("amodule"),
-            Module("amodule.inside"),
+            Dependency(Module("module")),
+            Dependency(Module("module.inside.module")),
+            Dependency(Module("amodule")),
+            Dependency(Module("amodule.inside")),
         )
     ),
-    "amodule.std_module": set((Module("module"), Module("module.inside.module"))),
+    "amodule.std_module": set(
+        (Dependency(Module("module")), Dependency(Module("module.inside.module")))
+    ),
 }

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -4,7 +4,7 @@ Test check use case.
 
 from unittest.mock import Mock
 
-from dep_check.models import Module, ModuleWildcard
+from dep_check.models import Module, ModuleWildcard, SourceCode, SourceFile
 from dep_check.use_cases.check import (
     CheckDependenciesUC,
     DependencyError,
@@ -45,14 +45,16 @@ def test_empty_rules(source_files) -> None:
             DependencyError(
                 SIMPLE_FILE.module, Module("module.inside.module"), tuple()
             ),
-            DependencyError(SIMPLE_FILE.module, Module("amodule"), tuple()),
+            DependencyError(SIMPLE_FILE.module, Module("amodule.aclass"), tuple()),
             DependencyError(FILE_WITH_LOCAL_IMPORT.module, Module("module"), tuple()),
             DependencyError(
                 FILE_WITH_LOCAL_IMPORT.module, Module("module.inside.module"), tuple()
             ),
-            DependencyError(FILE_WITH_LOCAL_IMPORT.module, Module("amodule"), tuple()),
             DependencyError(
-                FILE_WITH_LOCAL_IMPORT.module, Module("amodule.inside"), tuple()
+                FILE_WITH_LOCAL_IMPORT.module, Module("amodule.aclass"), tuple()
+            ),
+            DependencyError(
+                FILE_WITH_LOCAL_IMPORT.module, Module("amodule.inside.aclass"), tuple()
             ),
             DependencyError(FILE_WITH_STD_IMPORT.module, Module("module"), tuple()),
             DependencyError(
@@ -122,23 +124,25 @@ def test_not_passing_rules(source_files) -> None:
     assert set(error_printer.print.call_args[0][0]) == set(
         (
             DependencyError(
-                simple, Module("module"), tuple(set(dep_rules["simple_module"]))
-            ),
-            DependencyError(
-                local, Module("amodule"), tuple(set(dep_rules["amodule.local_module"]))
+                simple, Module("module"), tuple(sorted(dep_rules["simple_module"]))
             ),
             DependencyError(
                 local,
-                Module("amodule.inside"),
-                tuple(set(dep_rules["amodule.local_module"])),
+                Module("amodule.aclass"),
+                tuple(sorted(dep_rules["amodule.local_module"])),
             ),
             DependencyError(
-                std, Module("module"), tuple(set(dep_rules["amodule.std_module"]))
+                local,
+                Module("amodule.inside.aclass"),
+                tuple(sorted(dep_rules["amodule.local_module"])),
+            ),
+            DependencyError(
+                std, Module("module"), tuple(sorted(dep_rules["amodule.std_module"]))
             ),
             DependencyError(
                 std,
                 Module("module.inside.module"),
-                tuple(set(dep_rules["amodule.std_module"])),
+                tuple(sorted(dep_rules["amodule.std_module"])),
             ),
         )
     )
@@ -158,3 +162,63 @@ def test_get_rules_with_init_module():
 
     # Then
     assert rules == {(ModuleWildcard(module), ModuleWildcard("module%"))}
+
+
+def test_passing_rules_with_import_from() -> None:
+    """
+    Test result with a set rules that accept files.
+    """
+    # Given
+    configuration = Configuration(
+        dependency_rules={
+            "module": [ModuleWildcard("module%"), ModuleWildcard("amodule.submodule")]
+        }
+    )
+    source_file = SourceFile("module", SourceCode("from amodule import submodule"))
+    configuration_reader = build_conf_reader_stub(configuration)
+    error_printer = Mock()
+    use_case = CheckDependenciesUC(
+        configuration_reader, error_printer, iter([source_file])
+    )
+
+    # When
+    use_case.run()
+
+    # Then
+    configuration_reader.read.assert_called()  # type: ignore
+    error_printer.print.assert_called_with([])
+
+
+def test_not_passing_rules_with_import_from() -> None:
+    """
+    Test result with a set rules that accept files.
+    """
+    # Given
+    dep_rules = {
+        "module": [ModuleWildcard("module%"), ModuleWildcard("amodule.submodule")]
+    }
+    configuration = Configuration(dep_rules)
+    source_file = SourceFile(
+        "module", SourceCode("from amodule import othermodule, submodule\n")
+    )
+    configuration_reader = build_conf_reader_stub(configuration)
+    error_printer = Mock()
+    use_case = CheckDependenciesUC(
+        configuration_reader, error_printer, iter([source_file])
+    )
+
+    # When
+    use_case.run()
+
+    # Then
+    configuration_reader.read.assert_called()  # type: ignore
+    error_printer.print.assert_called()  # type: ignore
+    assert set(error_printer.print.call_args[0][0]) == set(
+        (
+            DependencyError(
+                "module",
+                Module("amodule.othermodule"),
+                tuple(sorted(dep_rules["module"])),
+            ),
+        )
+    )

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -6,7 +6,7 @@ from typing import List
 from pytest import raises
 
 from dep_check.checker import NotAllowedDependencyException, check_dependency
-from dep_check.models import Module, ModuleWildcard, Rules
+from dep_check.models import Dependency, Module, ModuleWildcard, Rules
 
 
 def test_empty() -> None:
@@ -14,7 +14,7 @@ def test_empty() -> None:
     Test empty rules case.
     """
     # Given
-    dependency = Module("toto")
+    dependency = Dependency(Module("toto"))
     authorized_modules: List[ModuleWildcard] = []
 
     # When
@@ -23,7 +23,7 @@ def test_empty() -> None:
 
     # Then
     assert error
-    assert error.value.dependency == dependency
+    assert error.value.dependency == dependency.main_import
     assert error.value.authorized_modules == authorized_modules
 
 
@@ -32,7 +32,7 @@ def test_passing_case() -> None:
     Test a passing case.
     """
     # Given
-    dependency = Module("toto")
+    dependency = Dependency(Module("toto"))
     rules: Rules = [
         (ModuleWildcard("toto"), ModuleWildcard("to*")),
         (ModuleWildcard("toto"), ModuleWildcard("titi.tata")),
@@ -54,7 +54,7 @@ def test_not_passing_case() -> None:
     Test a not passing case.
     """
     # Given
-    dependency = Module("toto.tata")
+    dependency = Dependency(Module("toto.tata"))
     rules: Rules = [
         (ModuleWildcard("toto.*"), ModuleWildcard("toto")),
         (ModuleWildcard("toto.*"), ModuleWildcard("te.*")),
@@ -67,5 +67,5 @@ def test_not_passing_case() -> None:
 
     # Then
     assert error
-    assert error.value.dependency == dependency
+    assert error.value.dependency == dependency.main_import
     assert error.value.authorized_modules == [r for _, r in rules]

--- a/tests/test_draw_graph.py
+++ b/tests/test_draw_graph.py
@@ -5,7 +5,7 @@ from typing import Iterator
 from unittest.mock import Mock, patch
 
 from dep_check.infra.io import Graph, GraphDrawer
-from dep_check.models import Module, SourceFile
+from dep_check.models import Dependency, Module, SourceFile
 from dep_check.use_cases.draw_graph import DrawGraphUC, _fold_dep
 
 from .fakefile import GLOBAL_DEPENDENCIES, SIMPLE_FILE
@@ -139,10 +139,18 @@ def test_fold_dep() -> None:
     # Then
     assert global_dep == {
         "simple_module": set(
-            (Module("module"), Module("module.inside.module"), Module("amodule"))
+            (
+                Dependency(Module("module")),
+                Dependency(Module("module.inside.module")),
+                Dependency(Module("amodule")),
+            )
         ),
         "amodule": set(
-            (Module("module"), Module("module.inside.module"), Module("amodule"))
+            (
+                Dependency(Module("module")),
+                Dependency(Module("module.inside.module")),
+                Dependency(Module("amodule")),
+            )
         ),
     }
 
@@ -165,9 +173,15 @@ def test_fold_module(source_files) -> None:
 
     assert global_dep == {
         "simple_module": set(
-            (Module("module"), Module("module.inside.module"), Module("amodule"))
+            (
+                Dependency(Module("module")),
+                Dependency(Module("module.inside.module")),
+                Dependency(Module("amodule")),
+            )
         ),
-        "amodule": set((Module("module"), Module("module.inside.module"))),
+        "amodule": set(
+            (Dependency(Module("module")), Dependency(Module("module.inside.module")))
+        ),
     }
 
 
@@ -216,7 +230,9 @@ def test_hide_nominal(source_files) -> None:
     global_dep = drawer.write.call_args[0][0]
 
     assert global_dep == {
-        "simple_module": set((Module("module"), Module("module.inside.module")))
+        "simple_module": set(
+            (Dependency(Module("module")), Dependency(Module("module.inside.module")))
+        )
     }
 
 
@@ -232,7 +248,9 @@ def test_pop_empty_module_from_dependencies(source_files) -> None:
     # Then
     drawer.write.assert_called_with(
         {
-            "simple_module": set((Module("amodule"),)),
-            "amodule.local_module": set((Module("amodule"), Module("amodule.inside"))),
+            "simple_module": set((Dependency(Module("amodule")),)),
+            "amodule.local_module": set(
+                (Dependency(Module("amodule")), Dependency(Module("amodule.inside")))
+            ),
         }
     )

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -1,50 +1,28 @@
 """
 Tests about find_dependencies function.
 """
-from dep_check.dependency_finder import find_dependencies
-from dep_check.models import Module, SourceCode, SourceFile
-
-
-def test_empty() -> None:
-    """
-    Test empty code case.
-    """
-    # Given
-    module = Module("")
-    source_code = SourceCode("")
-    source_file = SourceFile(module=module, code=source_code)
-
-    # When
-    dependencies = find_dependencies(source_file)
-
-    # Then
-    assert dependencies == set()
-
+from dep_check.dependency_finder import find_dependencies, find_import_from_dependencies
+from dep_check.models import Dependency, Module, SourceCode, SourceFile
 
 _SIMPLE_CASE = """
 import simple
 import module.inside.module
 from amodule import aclass
 """
-_SIMPLE_RESULT = set(
-    (Module("simple"), Module("amodule"), Module("module.inside.module"))
+_SIMPLE_RESULT = frozenset(
+    (
+        Dependency(Module("simple")),
+        Dependency(Module("amodule")),
+        Dependency(Module("module.inside.module")),
+    )
 )
-
-
-def test_simple_case() -> None:
-    """
-    Test simple code case.
-    """
-    # Given
-    module = Module("toto_program")
-    source_file = SourceFile(module=module, code=SourceCode(_SIMPLE_CASE))
-
-    # When
-    dependencies = find_dependencies(source_file)
-
-    # Then
-    assert dependencies == _SIMPLE_RESULT
-
+_SIMPLE_RESULT_IMPORT_FROM = frozenset(
+    (
+        Dependency(Module("simple")),
+        Dependency(Module("amodule"), frozenset((Module("aclass"),))),
+        Dependency(Module("module.inside.module")),
+    )
+)
 
 _LOCAL_CASE = """
 import simple
@@ -52,20 +30,140 @@ from . import aclass
 from .inside.module import aclass
 """
 _LOCAL_RESULT = set(
-    (Module("simple"), Module("module"), Module("module.inside.module"))
+    (
+        Dependency(Module("simple")),
+        Dependency(Module("module")),
+        Dependency(Module("module.inside.module")),
+    )
+)
+_LOCAL_RESULT_IMPORT_FROM = set(
+    (
+        Dependency(Module("simple")),
+        Dependency(Module("module"), frozenset((Module("aclass"),))),
+        Dependency(Module("module.inside.module"), frozenset((Module("aclass"),))),
+    )
 )
 
 
-def test_local_import_case() -> None:
-    """
-    Test code with local import case.
-    """
-    # Given
-    module = Module("module.toto")
-    source_file = SourceFile(module=module, code=SourceCode(_LOCAL_CASE))
+class TestFindDependencies:
+    @staticmethod
+    def test_empty() -> None:
+        """
+        Test empty code case.
+        """
+        # Given
+        module = Module("")
+        source_code = SourceCode("")
+        source_file = SourceFile(module=module, code=source_code)
 
-    # When
-    dependencies = find_dependencies(source_file)
+        # When
+        dependencies = find_dependencies(source_file)
 
-    # Then
-    assert dependencies == _LOCAL_RESULT
+        # Then
+        assert dependencies == frozenset()
+
+    @staticmethod
+    def test_simple_case() -> None:
+        """
+        Test simple code case.
+        """
+        # Given
+        module = Module("toto_program")
+        source_file = SourceFile(module=module, code=SourceCode(_SIMPLE_CASE))
+
+        # When
+        dependencies = find_dependencies(source_file)
+
+        # Then
+        assert dependencies == _SIMPLE_RESULT
+
+    @staticmethod
+    def test_local_import_case() -> None:
+        """
+        Test code with local import case.
+        """
+        # Given
+        module = Module("module.toto")
+        source_file = SourceFile(module=module, code=SourceCode(_LOCAL_CASE))
+
+        # When
+        dependencies = find_dependencies(source_file)
+
+        # Then
+        assert dependencies == _LOCAL_RESULT
+
+
+class TestFindImportFromDependencies:
+    @staticmethod
+    def test_empty() -> None:
+        """
+        Test empty code case.
+        """
+        # Given
+        module = Module("")
+        source_code = SourceCode("")
+        source_file = SourceFile(module=module, code=source_code)
+
+        # When
+        dependencies = find_import_from_dependencies(source_file)
+
+        # Then
+        assert dependencies == frozenset()
+
+    @staticmethod
+    def test_simple_case() -> None:
+        """
+        Test simple code case.
+        """
+        # Given
+        module = Module("toto_program")
+        source_file = SourceFile(module=module, code=SourceCode(_SIMPLE_CASE))
+
+        # When
+        dependencies = find_import_from_dependencies(source_file)
+
+        # Then
+        assert dependencies == _SIMPLE_RESULT_IMPORT_FROM
+
+    @staticmethod
+    def test_local_import_case() -> None:
+        """
+        Test code with local import case.
+        """
+        # Given
+        module = Module("module.toto")
+        source_file = SourceFile(module=module, code=SourceCode(_LOCAL_CASE))
+
+        # When
+        dependencies = find_import_from_dependencies(source_file)
+
+        # Then
+        assert dependencies == _LOCAL_RESULT_IMPORT_FROM
+
+    @staticmethod
+    def test_multi_imports_after_from() -> None:
+        # Given
+        module = Module("module.toto")
+        source_file = SourceFile(
+            module=module,
+            code=SourceCode("from module import amodule, othermodule, moduleagain"),
+        )
+
+        # When
+        dependencies = find_import_from_dependencies(source_file)
+
+        # Then
+        assert dependencies == set(
+            (
+                Dependency(
+                    Module("module"),
+                    frozenset(
+                        (
+                            Module("amodule"),
+                            Module("othermodule"),
+                            Module("moduleagain"),
+                        )
+                    ),
+                ),
+            )
+        )


### PR DESCRIPTION
…t the from...import... dependencies


Dependency.main_import is the module that is imported
Dependency.other_imports are the modules imported after "from...import " 

`import module` -> Dependency.main_import = "module", other_imports = {}
`from amodule import module, submodule` -> Dependency.main_import = amodule, other_imports = {"amodule.module", "amodule.submodule"}