### PR TITLE
fix(return-code): simply check error flow and work with other use-cases

### DIFF
--- a/dep_check/main.py
+++ b/dep_check/main.py
@@ -209,7 +209,7 @@ def main() -> None:
         logging.error(
             "You have to write which feature you want to use among [build,check,graph]"
         )
-        sys.exit(1)
+        sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/dep_check/use_cases/check.py
+++ b/dep_check/use_cases/check.py
@@ -13,7 +13,11 @@ from dep_check.dependency_finder import IParser, get_import_from_dependencies
 from dep_check.models import Module, ModuleWildcard, Rules, SourceFile
 
 from .app_configuration import AppConfigurationSingleton
-from .interfaces import Configuration, ExitCode
+from .interfaces import Configuration
+
+
+class ForbiddenDepencyError(Exception):
+    pass
 
 
 @dataclass(frozen=True)
@@ -110,7 +114,7 @@ class CheckDependenciesUC:
                     tuple(sorted(error.authorized_modules)),
                 )
 
-    def run(self) -> ExitCode:
+    def run(self) -> None:
         errors = []
         nb_files = 0
 
@@ -122,4 +126,5 @@ class CheckDependenciesUC:
         unused = self.all_rules.difference(self.used_rules)
         self.report_printer.print_report(errors, unused, nb_files)
 
-        return ExitCode.OK if not errors else ExitCode.KO
+        if errors:
+            raise ForbiddenDepencyError

--- a/dep_check/use_cases/interfaces.py
+++ b/dep_check/use_cases/interfaces.py
@@ -3,7 +3,6 @@ Common use cases interfaces.
 """
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from enum import Enum
 
 from dep_check.models import Dependencies, DependencyRules
 
@@ -29,12 +28,3 @@ class IStdLibFilter(ABC):
         """
         Remove dependencies that are part of stdlib.
         """
-
-
-class ExitCode(Enum):
-    """
-    Describe possible exit codes
-    """
-
-    OK = 0
-    KO = 1

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -6,12 +6,18 @@ from unittest.mock import Mock
 
 from dep_check.infra.python_parser import PythonParser
 from dep_check.models import Module, ModuleWildcard, SourceCode, SourceFile
-from dep_check.use_cases.check import CheckDependenciesUC, DependencyError
+from dep_check.use_cases.check import (
+    CheckDependenciesUC,
+    DependencyError,
+    ForbiddenDepencyError,
+)
 from dep_check.use_cases.interfaces import Configuration
 
 from .fakefile import FILE_WITH_LOCAL_IMPORT, FILE_WITH_STD_IMPORT, SIMPLE_FILE
 
 PARSER = PythonParser()
+
+import pytest
 
 
 def test_empty_rules(source_files) -> None:
@@ -24,7 +30,8 @@ def test_empty_rules(source_files) -> None:
     use_case = CheckDependenciesUC(configuration, report_printer, PARSER, source_files)
 
     # When
-    use_case.run()
+    with pytest.raises(ForbiddenDepencyError):
+        use_case.run()
 
     # Then
     assert set(report_printer.print_report.call_args[0][0]) == set(
@@ -97,7 +104,8 @@ def test_not_passing_rules(source_files) -> None:
     use_case = CheckDependenciesUC(configuration, report_printer, PARSER, source_files)
 
     # When
-    use_case.run()
+    with pytest.raises(ForbiddenDepencyError):
+        use_case.run()
 
     # Then
     simple = SIMPLE_FILE.module
@@ -172,7 +180,8 @@ def test_not_passing_rules_with_import_from() -> None:
     )
 
     # When
-    use_case.run()
+    with pytest.raises(ForbiddenDepencyError):
+        use_case.run()
 
     # Then
     assert set(report_printer.print_report.call_args[0][0]) == set(

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -4,6 +4,8 @@ Test check use case.
 
 from unittest.mock import Mock
 
+import pytest
+
 from dep_check.infra.python_parser import PythonParser
 from dep_check.models import Module, ModuleWildcard, SourceCode, SourceFile
 from dep_check.use_cases.check import (
@@ -16,8 +18,6 @@ from dep_check.use_cases.interfaces import Configuration
 from .fakefile import FILE_WITH_LOCAL_IMPORT, FILE_WITH_STD_IMPORT, SIMPLE_FILE
 
 PARSER = PythonParser()
-
-import pytest
 
 
 def test_empty_rules(source_files) -> None:


### PR DESCRIPTION
Currently in graph, build use cases we don't return an `ExitCode`, this cause an error at the end of execution. By the way, I found it simpler to manage check error flow with exception.