### PR TITLE
fix(use_cases): remove ExitCode usage

### DIFF
--- a/dep_check/use_cases/build.py
+++ b/dep_check/use_cases/build.py
@@ -8,7 +8,7 @@ from dep_check.dependency_finder import IParser, get_dependencies
 from dep_check.models import Dependencies, Module, ModuleWildcard, SourceFile
 
 from .app_configuration import AppConfigurationSingleton
-from .interfaces import Configuration, ExitCode
+from .interfaces import Configuration
 
 
 class IConfigurationWriter(ABC):
@@ -42,7 +42,7 @@ class BuildConfigurationUC:
         self.source_files = source_files
         self.lang = lang
 
-    def run(self) -> ExitCode:
+    def run(self) -> None:
         """
         Build configuration from existing source files.
         """
@@ -60,5 +60,3 @@ class BuildConfigurationUC:
             ]
 
         self.printer.write(Configuration(dependency_rules, self.lang))
-
-        return ExitCode.OK

--- a/dep_check/use_cases/draw_graph.py
+++ b/dep_check/use_cases/draw_graph.py
@@ -15,7 +15,6 @@ from dep_check.models import (
 )
 
 from .app_configuration import AppConfigurationSingleton
-from .interfaces import ExitCode
 
 
 class IGraphDrawer(ABC):
@@ -81,7 +80,7 @@ class DrawGraphUC:
 
         return filtered_global_dep
 
-    def run(self) -> ExitCode:
+    def run(self) -> None:
         global_dependencies: GlobalDependencies = {}
         for source_file in self.source_files:
             module = Module(source_file.module.replace(".__init__", ""))
@@ -102,5 +101,3 @@ class DrawGraphUC:
                 global_dependencies.pop(module, None)
 
         self.drawer.write(global_dependencies)
-
-        return ExitCode.OK


### PR DESCRIPTION
This effectively reverts 751ae02a773e9411c44121a95d765b3ca67a8361, which was itself made obsolete by
9bab81ed2a0f50f316bee2d5fb429e33d6b6c153