### PR TITLE
Fix/build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,8 @@ include LICENSE
 include README.md
 include dep_check/infra/lib/find_dependencies.go
 include dep_check/infra/lib/goparse.c
+include dep_check/infra/lib/goparse.h
+include dep_check/infra/lib/setup.py
 
 recursive-include tests *
 recursive-exclude * __pycache__

--- a/dep_check/infra/go_parser.py
+++ b/dep_check/infra/go_parser.py
@@ -6,14 +6,14 @@ from dep_check.dependency_finder import IParser
 from dep_check.models import Dependencies, Dependency, ModuleWildcard, SourceFile
 
 try:
-    from dep_check.infra.lib import goparse
+    from .lib import goparse
 except ImportError:
     CURRENT_WD = getcwd()
 
     chdir("{}/lib".format(path.dirname(path.realpath(__file__))))
     try:
         run(["python3", "setup.py", "build_ext", "-i"], check=True)
-        from lib import goparse  # pylint: disable=no-name-in-module
+        from .lib import goparse  # pylint: disable=no-name-in-module
     except (CalledProcessError, FileNotFoundError):
         logging.warning(
             "Couldn't load GO library, you won't be able to use dep-check on GO projects."
@@ -52,9 +52,3 @@ class GoParser(IParser):
 
     def find_import_from_dependencies(self, source_file: SourceFile) -> Dependencies:
         return self.find_dependencies(source_file)
-
-
-if __name__ == "__main__":
-    print(goparse)
-    print(goparse.find_dependencies)
-    print(goparse.find_dependencies('package main\nimport ("fmt";"toto";"toto/tata")'))

--- a/dep_check/infra/go_parser.py
+++ b/dep_check/infra/go_parser.py
@@ -1,20 +1,19 @@
 import logging
-from os import chdir, environ, getcwd, path
+from os import chdir, getcwd, path
 from subprocess import CalledProcessError, run
 
 from dep_check.dependency_finder import IParser
 from dep_check.models import Dependencies, Dependency, ModuleWildcard, SourceFile
 
 try:
-    from .lib import goparse
+    from dep_check.infra.lib import goparse
 except ImportError:
     CURRENT_WD = getcwd()
 
     chdir("{}/lib".format(path.dirname(path.realpath(__file__))))
     try:
-        environ["CGO_ENABLED"] = "1"
-        run(["go", "build", "-buildmode=c-shared", "-o", "goparse.so"], check=True)
-        from .lib import goparse  # pylint: disable=no-name-in-module
+        run(["python3", "setup.py", "build_ext", "-i"], check=True)
+        from lib import goparse  # pylint: disable=no-name-in-module
     except (CalledProcessError, FileNotFoundError):
         logging.warning(
             "Couldn't load GO library, you won't be able to use dep-check on GO projects."
@@ -53,3 +52,9 @@ class GoParser(IParser):
 
     def find_import_from_dependencies(self, source_file: SourceFile) -> Dependencies:
         return self.find_dependencies(source_file)
+
+
+if __name__ == "__main__":
+    print(goparse)
+    print(goparse.find_dependencies)
+    print(goparse.find_dependencies('package main\nimport ("fmt";"toto";"toto/tata")'))

--- a/dep_check/infra/lib/find_dependencies.go
+++ b/dep_check/infra/lib/find_dependencies.go
@@ -1,10 +1,8 @@
 package main
 
-// #cgo pkg-config: python3
-// #define Py_LIMITED_API
+// #include <stdlib.h>
 // #include <Python.h>
-// int PyArg_ParseTuple_str(PyObject *, char **);
-// PyObject * Py_BuildValue_str(PyObject * args, char * src);
+// #include "goparse.h"
 import "C"
 
 import (
@@ -17,7 +15,7 @@ import (
 func find_dependencies(self, args *C.PyObject) *C.PyObject {
 	var src *C.char
 	if C.PyArg_ParseTuple_str(args, &src) == 0 {
-		return nil
+		return C.Py_return_None()
 	}
 
 	fset := token.NewFileSet() // positions are relative to fset
@@ -26,7 +24,7 @@ func find_dependencies(self, args *C.PyObject) *C.PyObject {
 	f, err := parser.ParseFile(fset, "", C.GoString(src), parser.ImportsOnly)
 	if err != nil {
 		fmt.Println(err)
-		return nil
+		return C.Py_return_None()
 	}
 
 	// Print the imports from the file's AST.

--- a/dep_check/infra/lib/goparse.c
+++ b/dep_check/infra/lib/goparse.c
@@ -1,4 +1,3 @@
-#define Py_LIMITED_API
 #include <Python.h>
 
 PyObject * find_dependencies(PyObject *, PyObject *);
@@ -8,6 +7,13 @@ PyObject * find_dependencies(PyObject *, PyObject *);
 int PyArg_ParseTuple_str(PyObject * args, char ** src) {
     return PyArg_ParseTuple(args, "s", src);
 }
+
+// Fix SystemError: built-in function gen_nums returned NULL without setting an error
+// see https://stackoverflow.com/a/40688635
+PyObject *Py_return_None() {
+        Py_RETURN_NONE;
+}
+
 
 static PyMethodDef GoParseMethods[] = {
     {"find_dependencies", find_dependencies, METH_VARARGS, "Parses a file and returns its dependencies."},

--- a/dep_check/infra/lib/goparse.h
+++ b/dep_check/infra/lib/goparse.h
@@ -1,0 +1,10 @@
+#ifndef _GOPARSE_H
+#define _GOPARSE_H
+
+int PyArg_ParseTuple_str(PyObject *, char **);
+
+PyObject * Py_BuildValue_str(PyObject * args, char * src);
+
+PyObject *Py_return_None();
+
+#endif

--- a/dep_check/infra/lib/setup.py
+++ b/dep_check/infra/lib/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup, Extension
+
+setup(
+    name='goparse',
+    version='1.0',
+    description='Parses a file and returns its dependencies',
+    build_golang={'root': 'dep-check'},
+    ext_modules=[
+        Extension(
+            'goparse',
+            sources=['find_dependencies.go'],
+            py_limited_api=True,
+            define_macros=[('Py_LIMITED_API', None)],
+        )
+    ],
+    setup_requires=['setuptools-golang'],
+
+)

--- a/dependency_config.yaml
+++ b/dependency_config.yaml
@@ -14,6 +14,9 @@ dependency_rules:
   dep_check.infra.std_lib_filter:
     - dep_check.use_cases.interfaces
 
+  dep_check.infra.lib*:
+    - setuptools*
+
   dep_check.infra.go_parser:
     - dep_check.infra.lib.goparse
 


### PR DESCRIPTION
Using https://github.com/asottile/setuptools-golang and setup.py to correctly configure build tool-chain, cross-platform compliant. 

Now I can build the goparse from MacOsX

Also, replacing incompatible `nil` (Translated no `NULL`)  to `C.Py_return_None()` (translated to `None`). With the first one, the programs exists with a : `SystemError: error return without exception set`