### PR TITLE
chore(deploy): prepare release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,5 @@
 include LICENSE
 include README.md
-include dep_check/infra/lib/find_dependencies.go
-include dep_check/infra/lib/goparse.c
-include dep_check/infra/lib/goparse.h
 include dep_check/infra/lib/setup.py
 
 recursive-include tests *

--- a/dep_check/__init__.py
+++ b/dep_check/__init__.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
-
 """Top-level package for dep-check."""
 
 __author__ = """LumApps"""
 __email__ = "core-devs@lumapps.com"
-__version__ = "1.0.4dev"
+__version__ = "2.0.1"

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 2.0.1(2022-06-02)
+
+### MAJOR
+
+- Drop go compatibility.
+- Update python support, tested on 3.8, 3.9, 3.10.
+- Add `error_on_unused` option to raise an error when unused rules are detected.
+
 ## 1.0.3(2019-08-26)
 
 ### BUGFIX


### PR DESCRIPTION
## Global summary

Prepare the repo for version `2.0.1`.

Why `2` ?

because we drop `go` compatibility

Why `.0.1` ?

Little oupsy, I create a tag `2.0.0` without prepare it :face_palm:
