### PR TITLE
feat(dynamic-rules): propose a new feature

### DIFF
--- a/dep_check/checker.py
+++ b/dep_check/checker.py
@@ -5,7 +5,13 @@ import re
 from typing import List, Optional
 
 from dep_check.dependency_finder import IParser
-from dep_check.models import Dependency, Module, ModuleWildcard, Rule, Rules
+from dep_check.models import (
+    Dependency,
+    MatchingRule,
+    MatchingRules,
+    Module,
+    ModuleWildcard,
+)
 
 
 class NotAllowedDependencyException(Exception):
@@ -23,39 +29,44 @@ class NotAllowedDependencyException(Exception):
         self.authorized_modules = authorized_modules
 
 
-def check_dependency(parser: IParser, dependency: Dependency, rules: Rules) -> Rules:
+def check_dependency(
+    parser: IParser, dependency: Dependency, matching_rules: MatchingRules
+) -> MatchingRules:
     """
     Check that dependencies match a given set of rules.
     """
-    used_rule: Optional[Rule] = None
-    for module, rule in rules:
-        if re.match(f"{parser.wildcard_to_regex(rule)}$", dependency.main_import):
-            used_rule = (module, rule)
+    used_rule: Optional[MatchingRule] = None
+    for matching_rule in matching_rules:
+        if re.match(
+            f"{parser.wildcard_to_regex(matching_rule.specific_rule_wildcard)}$",
+            dependency.main_import,
+        ):
+            used_rule = matching_rule
             return set((used_rule,))
     if not dependency.sub_imports:
         raise NotAllowedDependencyException(
-            dependency.main_import, [r for _, r in rules]
+            dependency.main_import, [r.specific_rule_wildcard for r in matching_rules]
         )
 
-    return check_import_from_dependency(parser, dependency, rules)
+    return check_import_from_dependency(parser, dependency, matching_rules)
 
 
 def check_import_from_dependency(
-    parser: IParser, dependency: Dependency, rules: Rules
-) -> Rules:
-    used_rules: Rules = set()
+    parser: IParser, dependency: Dependency, matching_rules: MatchingRules
+) -> MatchingRules:
+    used_rules: MatchingRules = set()
     for import_module in dependency.sub_imports:
         used_rule = None
-        for module, rule in rules:
+        for matching_rule in matching_rules:
             if re.match(
-                f"{parser.wildcard_to_regex(rule)}$",
+                f"{parser.wildcard_to_regex(matching_rule.specific_rule_wildcard)}$",
                 f"{dependency.main_import}.{import_module}",
             ):
-                used_rule = (module, rule)
+                used_rule = matching_rule
                 used_rules.add(used_rule)
         if not used_rule:
             raise NotAllowedDependencyException(
                 Module(f"{dependency.main_import}.{import_module}"),
-                [r for _, r in rules],
+                [r.specific_rule_wildcard for r in matching_rules],
             )
     return used_rules

--- a/dep_check/infra/python_parser.py
+++ b/dep_check/infra/python_parser.py
@@ -89,6 +89,7 @@ class PythonParser(IParser):
         """
         module_regex = module.replace(".", "\\.").replace("*", ".*")
         module_regex = module_regex.replace("[!", "[^").replace("?", ".?")
+        module_regex = module_regex.replace("(<", "(?P<")
 
         # Special char including a module along with all its sub-modules:
         module_regex = module_regex.replace("%", r"(\..*)?$")

--- a/dep_check/models.py
+++ b/dep_check/models.py
@@ -35,6 +35,20 @@ DependencyRules = Dict[str, List[ModuleWildcard]]
 GlobalDependencies = Dict[Module, Dependencies]
 
 
+@dataclass(frozen=True)
+class MatchingRule:
+    module_wildcard: ModuleWildcard
+    original_rule_wildcard: ModuleWildcard
+    specific_rule_wildcard: ModuleWildcard
+
+    @property
+    def original_rule(self) -> Rule:
+        return (self.module_wildcard, self.original_rule_wildcard)
+
+
+MatchingRules = Set[MatchingRule]
+
+
 def get_parent(module: Module) -> Module:
     """
     Get the parent module of a given one.

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -96,6 +96,21 @@ mymodule:
     - '*'
 ```
 
+### Advance usage
+
+You can make dynamic rules using following syntax:
+
+* `(<bind_name>any_wildcard)` to get a part of the module reusable in rules
+* `module.<bind_name>.any_wildcard` to reuse the part in rule
+
+```yaml
+mymodule.(<submodule>%).module:
+    - mymodule%
+    - amodule.{submodule}.*
+    - othermodul?_[0-9]
+```
+
+
 ## Check your configuration
 
 Once your config file is ready, run


### PR DESCRIPTION
## General summary

Allow to make dynamic rules, e.g.:
```yaml
engines.(<engine>[!.]+).use_cases%:
  - engines.{engine}.entities%

engines.(<engine>[!.]+).entrypoints%:
  - engines.{engine}%
```

Where
`engines.generational_engine.use_cases`:
```python
from engines.generational_engine.entities import Solution
```
Works :heavy_check_mark:

---

`engines.plne.use_cases`:
```python
from engines.plne.entities import Solution
```
Works :heavy_check_mark:

---

`engines.generational_engine.use_cases`:
```python
from engines.plne.entities import Solution
```
Fails :x: 