### PR TITLE
Add ~ rule for dep-check

### DIFF
--- a/dep_check/checker.py
+++ b/dep_check/checker.py
@@ -26,6 +26,31 @@ class NotAllowedDependencyException(Exception):
         self.authorized_modules = authorized_modules
 
 
+def _raise_on_forbidden_rules(
+    parser: IParser, dependency: Dependency, matching_rules: MatchingRules
+) -> MatchingRules:
+    # pylint: disable=too-many-nested-blocks
+    used_rules: MatchingRules = OrderedSet()
+    imports = [
+        dependency.main_import,
+        *[
+            Module(f"{dependency.main_import}.{sub_import}")
+            for sub_import in dependency.sub_imports
+        ],
+    ]
+    for module in imports:
+        for matching_rule in matching_rules:
+            regex_rule = parser.wildcard_to_regex(matching_rule.specific_rule_wildcard)
+            if regex_rule.raise_if_found:
+                if re.match(f"{regex_rule.regex}$", module):
+                    raise NotAllowedDependencyException(
+                        module, [r.specific_rule_wildcard for r in matching_rules]
+                    )
+                used_rules.add(matching_rule)
+
+    return used_rules
+
+
 def _find_matching_rules(
     parser: IParser, matching_rules: MatchingRules, dotted_import: Module
 ) -> MatchingRules:
@@ -49,16 +74,22 @@ def check_dependency(
     Check that dependencies match a given set of rules.
     """
 
+    forbidden_rules = _raise_on_forbidden_rules(parser, dependency, matching_rules)
     used_rules = _find_matching_rules(parser, matching_rules, dependency.main_import)
     if used_rules:
-        return used_rules
+        return OrderedSet([*used_rules, *forbidden_rules])
 
     if not dependency.sub_imports:
         raise NotAllowedDependencyException(
             dependency.main_import, [r.specific_rule_wildcard for r in matching_rules]
         )
 
-    return check_import_from_dependency(parser, dependency, matching_rules)
+    return OrderedSet(
+        [
+            *check_import_from_dependency(parser, dependency, matching_rules),
+            *forbidden_rules,
+        ]
+    )
 
 
 def check_import_from_dependency(

--- a/dep_check/dependency_finder.py
+++ b/dep_check/dependency_finder.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from dep_check.models import Dependencies, ModuleWildcard, SourceFile
+from dep_check.models import Dependencies, ModuleWildcard, RegexRule, SourceFile
 
 
 class IParser(ABC):
@@ -9,7 +9,7 @@ class IParser(ABC):
     """
 
     @abstractmethod
-    def wildcard_to_regex(self, module: ModuleWildcard) -> str:
+    def wildcard_to_regex(self, module: ModuleWildcard) -> RegexRule:
         """
         Return a regex expression for the Module from wildcard
         """

--- a/dep_check/models.py
+++ b/dep_check/models.py
@@ -75,3 +75,9 @@ class SourceFile:
 
     module: Module
     code: SourceCode
+
+
+@dataclass(frozen=True)
+class RegexRule:
+    regex: str
+    raise_if_found: bool = False

--- a/dep_check/use_cases/check.py
+++ b/dep_check/use_cases/check.py
@@ -91,7 +91,7 @@ class CheckDependenciesUC:
         matching_rules: MatchingRules = OrderedSet()
         for module_wildcard, rules in self.configuration.dependency_rules.items():
             match = re.match(
-                f"{self.parser.wildcard_to_regex(ModuleWildcard(module_wildcard))}$",
+                f"{self.parser.wildcard_to_regex(ModuleWildcard(module_wildcard)).regex}$",
                 module,
             )
             if match:

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -64,6 +64,7 @@ You can build your own configuration file, using wildcards. Here are those suppo
 * `[!d-y]` corresponds to any character which is **not** between 'd' and 'y'
 * `[!abc]` corresponds to any character except 'a', 'b' or 'c'
 * Use `%` after a module name (e.g. `my_module%`) to include this module along with its sub-modules.
+* Use `~` before a module name (e.g. `~my_module`) to forbid this module.
 
 ### Examples
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -96,7 +96,7 @@ mymodule:
     - '*'
 ```
 
-### Advance usage
+### Advanced usage
 
 You can make dynamic rules using following syntax:
 
@@ -109,7 +109,6 @@ mymodule.(<submodule>%).module:
     - amodule.{submodule}.*
     - othermodul?_[0-9]
 ```
-
 
 ## Check your configuration
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -191,10 +191,11 @@ class TestRegexToWildcard:
         module = ModuleWildcard("")
 
         # When
-        regex = PARSER.wildcard_to_regex(module)
+        regex_rule = PARSER.wildcard_to_regex(module)
 
         # Then
-        assert regex == ""
+        assert regex_rule.regex == ""
+        assert not regex_rule.raise_if_found
 
     @staticmethod
     def test_simple_module() -> None:
@@ -205,12 +206,13 @@ class TestRegexToWildcard:
         module = ModuleWildcard("toto")
 
         # When
-        regex = PARSER.wildcard_to_regex(module)
+        regex_rule = PARSER.wildcard_to_regex(module)
 
         # Then
-        assert re.match(regex, "toto")
-        assert not re.match(regex, "tata")
-        assert not re.match(regex, "titi.toto")
+        assert re.match(regex_rule.regex, "toto")
+        assert not re.match(regex_rule.regex, "tata")
+        assert not re.match(regex_rule.regex, "titi.toto")
+        assert not regex_rule.raise_if_found
 
     @staticmethod
     def test_nested_module() -> None:
@@ -221,13 +223,14 @@ class TestRegexToWildcard:
         module = ModuleWildcard("toto.tata")
 
         # When
-        regex = PARSER.wildcard_to_regex(module)
+        regex_rule = PARSER.wildcard_to_regex(module)
 
         # Then
-        assert re.match(regex, "toto.tata")
-        assert not re.match(regex, "toto")
-        assert not re.match(regex, "tata")
-        assert not re.match(regex, "titi.toto")
+        assert re.match(regex_rule.regex, "toto.tata")
+        assert not re.match(regex_rule.regex, "toto")
+        assert not re.match(regex_rule.regex, "tata")
+        assert not re.match(regex_rule.regex, "titi.toto")
+        assert not regex_rule.raise_if_found
 
     @staticmethod
     def test_quesiton_mark() -> None:
@@ -238,15 +241,16 @@ class TestRegexToWildcard:
         module = ModuleWildcard("t?to.?at?")
 
         # When
-        regex = PARSER.wildcard_to_regex(module)
+        regex_rule = PARSER.wildcard_to_regex(module)
 
         # Then
-        assert re.match(regex, "toto.tata")
-        assert re.match(regex, "t2to.bato")
-        assert re.match(regex, "t#to.!at&")
-        assert not re.match(regex, "toto")
-        assert not re.match(regex, "tata")
-        assert not re.match(regex, "toti.toto")
+        assert re.match(regex_rule.regex, "toto.tata")
+        assert re.match(regex_rule.regex, "t2to.bato")
+        assert re.match(regex_rule.regex, "t#to.!at&")
+        assert not re.match(regex_rule.regex, "toto")
+        assert not re.match(regex_rule.regex, "tata")
+        assert not re.match(regex_rule.regex, "toti.toto")
+        assert not regex_rule.raise_if_found
 
     @staticmethod
     def test_asterisk() -> None:
@@ -257,15 +261,16 @@ class TestRegexToWildcard:
         module = ModuleWildcard("toto*.*")
 
         # When
-        regex = PARSER.wildcard_to_regex(module)
+        regex_rule = PARSER.wildcard_to_regex(module)
 
         # Then
-        assert re.match(regex, "toto.tata")
-        assert re.match(regex, "toto_2351.titi")
-        assert re.match(regex, "toto_azerty.titi.toto.tata")
-        assert not re.match(regex, "toto")
-        assert not re.match(regex, "tototata")
-        assert not re.match(regex, "toti.toto")
+        assert re.match(regex_rule.regex, "toto.tata")
+        assert re.match(regex_rule.regex, "toto_2351.titi")
+        assert re.match(regex_rule.regex, "toto_azerty.titi.toto.tata")
+        assert not re.match(regex_rule.regex, "toto")
+        assert not re.match(regex_rule.regex, "tototata")
+        assert not re.match(regex_rule.regex, "toti.toto")
+        assert not regex_rule.raise_if_found
 
     @staticmethod
     def test_percentage() -> None:
@@ -276,11 +281,28 @@ class TestRegexToWildcard:
         module = ModuleWildcard("toto.tata%")
 
         # When
-        regex = PARSER.wildcard_to_regex(module)
+        regex_rule = PARSER.wildcard_to_regex(module)
 
         # Then
-        assert re.match(regex, "toto.tata")
-        assert re.match(regex, "toto.tata.titi")
-        assert re.match(regex, "toto.tata.titi.tutu.tototata.tititutu")
-        assert not re.match(regex, "toto")
-        assert not re.match(regex, "toto.tata_123")
+        assert re.match(regex_rule.regex, "toto.tata")
+        assert re.match(regex_rule.regex, "toto.tata.titi")
+        assert re.match(regex_rule.regex, "toto.tata.titi.tutu.tototata.tititutu")
+        assert not re.match(regex_rule.regex, "toto")
+        assert not re.match(regex_rule.regex, "toto.tata_123")
+        assert not regex_rule.raise_if_found
+
+    @staticmethod
+    def test_not() -> None:
+        """
+        Test not case
+        """
+        # Given
+        module = ModuleWildcard("~foo")
+
+        # When
+        regex_rule = PARSER.wildcard_to_regex(module)
+
+        # Then
+        assert re.match(regex_rule.regex, "foo")
+        assert not re.match(regex_rule.regex, "bar")
+        assert regex_rule.raise_if_found


### PR DESCRIPTION
As we use the dep-checker in a mono-repository, we have generic rules which might not apply to some services.
To "resolve" this, we include a bad design behavior, which is excluding paths instead.

```yaml
  myapp.$service.use_cases.$a%:
    - ~myapp.$service.entities.$b%
    - ~myapp.$service.use_cases.$b%
    - ~myapp.$service.interfaces.db.$b%

  myapp.$service.use_cases.$b%:
    - ~myapp.$service.entities.$a%
    - ~myapp.$service.use_cases.$a%
    - ~myapp.$service.interfaces.db.$a%
```